### PR TITLE
[FEAT] : make lost view

### DIFF
--- a/src/pages/Lost/views/Lost.tsx
+++ b/src/pages/Lost/views/Lost.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import LostDoc from './LostDoc';
+import SideBar from '../../../components/SideBar/SideBar';
 
 function Lost() {
 	return (
-        <div className='bg-nomad-sand min-h-full'>
-            <div className='grid grid-cols-2 gap-7 p-10 box-border'>
+        <>
+        <SideBar />
+        <div className='bg-nomad-sand min-h-full pt-9'>
+            <div className='grid grid-cols-2 gap-5 p-8 box-border'>
                 <LostDoc />
                 <LostDoc />
                 <LostDoc />
@@ -13,6 +16,7 @@ function Lost() {
                 <LostDoc />
             </div>
         </div>
+        </>
     )
 }
 

--- a/src/pages/Lost/views/LostDoc.tsx
+++ b/src/pages/Lost/views/LostDoc.tsx
@@ -3,10 +3,10 @@ import React from 'react';
 
 function LostDoc() {
 	return (
-        <div className='text-center cursor-pointer'>
+        <div className='text-center cursor-pointer bg-white rounded-xl p-3 shadow-full shadow-zinc-300'>
             <div className='relative pb-[100%] mb-2'>
                 <img src='https://webstatic.hoyoverse.com/upload/op-public/2023/05/19/df38144b11242c8787e51090e988c410_5760544583082283946.jpg'
-                    className='absolute object-cover h-full' alt='lost-img'/>
+                    className='absolute object-cover h-full rounded-lg' alt='lost-img'/>
             </div>
             <p className='font-nexonBold text-lg'>C5R6S8</p>
             <p className='text-xs'>2023-08-20</p>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -10,6 +10,9 @@ module.exports = {
 				'nomad-green': '#20633F',
 				'nomad-sand': '#FFFAF2',
 			},
+			boxShadow: {
+				'full': '0 0 3px 0 rgb(0 0 0 / 0.05)'
+			}
 		},
 		fontFamily: {
 			nexonBold: ['nexonBold'],


### PR DESCRIPTION
ClusterMapView를 PR할 때 Lost의 컴포넌트들도 같이 올라갔지만 어제 수정했던 사항은 병합되지 않아서 따로 올려요. 사이드바를 추가해놨고, 글 목록에서 하나의 글을 카드 형식으로 나타나도록 했어요. (어제 본 것 처럼 😉) 그 때 div의 shadow를 사방향으로 주는 css를 tailwind.config에 추가해서 다른 컴포넌트에도 쓸 수 있도록 했어요! 많이많이 사용해주세요!