### PR TITLE
[FEAT] : make SearchSeat Component

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@headlessui/react": "^1.7.17",
+    "@heroicons/react": "^2.0.18",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",

--- a/src/components/SearchSeat/ClusterComboBox.tsx
+++ b/src/components/SearchSeat/ClusterComboBox.tsx
@@ -1,0 +1,70 @@
+import React, { useState } from 'react';
+import { Combobox } from '@headlessui/react';
+import { ChevronUpDownIcon } from '@heroicons/react/24/outline';
+
+interface ClusterProp {
+	id: number;
+	name: string;
+}
+
+const clusters = [
+	{ id: 1, name: '1' },
+	{ id: 2, name: '2' },
+	{ id: 3, name: '3' },
+	{ id: 4, name: '4' },
+	{ id: 5, name: '5' },
+	{ id: 6, name: '6' },
+	{ id: 11, name: 'x1' },
+	{ id: 12, name: 'x2' },
+];
+
+function ClusterComboBox() {
+	const [selectedCluster, setSelectedCluster] = useState(clusters[0]);
+	const [query, setQuery] = useState('');
+
+	const filteredcluster =
+		query === ''
+			? clusters
+			: clusters.filter((cluster) =>
+					cluster.name.toLowerCase().replace(/\s+/g, '').includes(query.toLowerCase().replace(/\s+/g, '')),
+			  );
+
+	return (
+		<div className="w-12">
+			<Combobox value={selectedCluster} onChange={setSelectedCluster}>
+				<div className="relative">
+					<div className="relative w-full cursor-default overflow-hidden rounded-lg bg-white text-left">
+						<Combobox.Input
+							className="w-full border-none py-2 pl-2 pr-2 text-xl leading-5 text-black"
+							displayValue={(cluster: ClusterProp) => cluster.name}
+							onChange={(event) => setQuery(event.target.value)}
+						/>
+						<Combobox.Button className="absolute inset-y-0 right-0 flex items-center">
+							<ChevronUpDownIcon className="w-5 h-5" />
+						</Combobox.Button>
+					</div>
+
+					<Combobox.Options className="absolute mt-1 max-h-60 w-full overflow-auto rounded-md bg-white">
+						{filteredcluster.length === 0 && query !== '' ? (
+							<div className="relative select-none font-nexonLight text-xs text-gray-700">검색 불가</div>
+						) : (
+							filteredcluster.map((cluster) => (
+								<Combobox.Option
+									key={cluster.id}
+									className={({ active }) =>
+										`relative select-none py-2 pl-4 pr-3 ${active ? 'bg-nomad-green text-white' : 'text-gray-900'}`
+									}
+									value={cluster}
+								>
+									{({ selected }) => <span className={` ${selected ? '' : 'font-nexonLight'}`}>{cluster.name}</span>}
+								</Combobox.Option>
+							))
+						)}
+					</Combobox.Options>
+				</div>
+			</Combobox>
+		</div>
+	);
+}
+
+export default ClusterComboBox;

--- a/src/components/SearchSeat/RowComboBox.tsx
+++ b/src/components/SearchSeat/RowComboBox.tsx
@@ -1,0 +1,73 @@
+import React, { useState } from 'react';
+import { Combobox } from '@headlessui/react';
+import { ChevronUpDownIcon } from '@heroicons/react/24/outline';
+
+interface RowProp {
+	id: number;
+	name: string;
+}
+
+const rows = [
+	{ id: 1, name: '1' },
+	{ id: 2, name: '2' },
+	{ id: 3, name: '3' },
+	{ id: 4, name: '4' },
+	{ id: 5, name: '5' },
+	{ id: 6, name: '6' },
+	{ id: 7, name: '7' },
+	{ id: 8, name: '8' },
+	{ id: 9, name: '9' },
+	{ id: 10, name: '10' },
+	{ id: 11, name: '11' },
+];
+
+function RowComboBox() {
+	const [selectedRow, setSelectedRow] = useState(rows[0]);
+	const [query, setQuery] = useState('');
+
+	const filteredrow =
+		query === ''
+			? rows
+			: rows.filter((row) =>
+					row.name.toLowerCase().replace(/\s+/g, '').includes(query.toLowerCase().replace(/\s+/g, '')),
+			  );
+
+	return (
+		<div className="w-12">
+			<Combobox value={selectedRow} onChange={setSelectedRow}>
+				<div className="relative">
+					<div className="relative w-full cursor-default overflow-hidden rounded-lg bg-white text-left">
+						<Combobox.Input
+							className="w-full border-none py-2 pl-2 pr-2 text-xl leading-5 text-black"
+							displayValue={(row: RowProp) => row.name}
+							onChange={(event) => setQuery(event.target.value)}
+						/>
+						<Combobox.Button className="absolute inset-y-0 right-0 flex items-center">
+							<ChevronUpDownIcon className="w-5 h-5" />
+						</Combobox.Button>
+					</div>
+
+					<Combobox.Options className="absolute mt-1 max-h-60 w-full overflow-auto rounded-md bg-white">
+						{filteredrow.length === 0 && query !== '' ? (
+							<div className="relative select-none font-nexonLight text-xs text-gray-700">검색 불가</div>
+						) : (
+							filteredrow.map((row) => (
+								<Combobox.Option
+									key={row.id}
+									className={({ active }) =>
+										`relative select-none py-2 pl-4 pr-3 ${active ? 'bg-nomad-green text-white' : 'text-gray-900'}`
+									}
+									value={row}
+								>
+									{({ selected }) => <span className={` ${selected ? '' : 'font-nexonLight'}`}>{row.name}</span>}
+								</Combobox.Option>
+							))
+						)}
+					</Combobox.Options>
+				</div>
+			</Combobox>
+		</div>
+	);
+}
+
+export default RowComboBox;

--- a/src/components/SearchSeat/SearchSeat.tsx
+++ b/src/components/SearchSeat/SearchSeat.tsx
@@ -1,19 +1,51 @@
 import React from 'react';
+import ClusterComboBox from './ClusterComboBox';
+import RowComboBox from './RowComboBox';
 
 function SearchSeat() {
+	const [isStarred, setIsStarred] = React.useState<boolean>(false);
+	const [searchResult, setSearchResult] = React.useState<string>('');
+
+	const handleSearchClick = () => {
+		setSearchResult('"heeskim" 님께서 사용중입니다');
+	};
 	return (
-		<div className="grid border-4 border-nomad-green">
-			<div className="grid grid-cols-7">
-				<div>C</div>
-				<input></input>
-				<div>R</div>
-				<input></input>
-				<div>S</div>
-				<input></input>
-				<button type="button">검색</button>
+		<div
+			className={`mt-2 shadow-full shadow-zinc-300 bg-white text-black rounded-3xl flex flex-col space-y-1 justify-center w-72 ${
+				searchResult ? 'h-36' : 'h-20'
+			}`}
+		>
+			<div className="flex flex-row justify-center items-center space-x-1">
+				<div className="text-xl">C</div>
+				<ClusterComboBox />
+				<div className="text-xl">R</div>
+				<RowComboBox />
+				<div className="text-xl">S</div>
+				<RowComboBox />
+				<button
+					type="button"
+					className="rounded-3xl bg-nomad-green text-nomad-sand w-12 h-6"
+					onClick={handleSearchClick}
+				>
+					검색
+				</button>
 			</div>
-			{/* <SearchResult /> */}
-			<button type="button">즐겨찾기 추가</button>
+			{searchResult && (
+				<div className="flex flex-col justify-center items-center space-y-2">
+					<div className="flex justify-center items-center">{searchResult}</div>
+					<button
+						type="button"
+						className={`rounded-3xl text-sm  text-nomad-sand w-28 h-6 ${
+							isStarred ? 'bg-meeting-disable' : 'bg-nomad-green'
+						}`}
+						onClick={() => {
+							setIsStarred(true);
+						}}
+					>
+						{isStarred ? '즐겨찾기 완료' : '즐겨찾기 추가'}
+					</button>
+				</div>
+			)}
 		</div>
 	);
 }

--- a/src/components/SideBar/views/Menu.tsx
+++ b/src/components/SideBar/views/Menu.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { NavLink } from 'react-router-dom';
 
 interface MenuProps {
 	link: string;
@@ -9,7 +9,9 @@ interface MenuProps {
 function Menu({ link, name }: MenuProps) {
 	return (
 		<li className="z-50 w-full h-14 flex items-center justify-end text-nomad-sand text-xl transition-transform transform hover:scale-105">
-			<Link to={`${link}`}>{name}</Link>
+			<NavLink to={`${link}`} className={({ isActive }) => ` ${isActive ? 'font-nexonBold' : ''}`}>
+				{name}
+			</NavLink>
 		</li>
 	);
 }

--- a/src/components/SideBar/views/SideBar.tsx
+++ b/src/components/SideBar/views/SideBar.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
+import { Bars3Icon } from '@heroicons/react/24/outline';
 import SideBarContent from './SideBarContent';
 
 function SideBar() {
@@ -10,29 +11,18 @@ function SideBar() {
 			<div id="Header" className="z-40 w-full max-w-max-wid bg-nomad-sand fixed">
 				<div className="flex justify-between">
 					<Link to="/" className="h-15 mt-4 ml-4">
-						<div id="Logo" className="font-fugazRegular text-2xl text-nomad-green">
+						<div id="Logo" className="font-fugazRegular text-2xl text-nomad-green cursor-pointer">
 							42NOMAD
 						</div>
 					</Link>
 					{!isOpen && (
 						<div id="HamburgerButton" className="z-50 bg-transparent">
-							<button
-								type="button"
-								className="items-center z-50 transition-transform transform hover:scale-110 mt-2 mr-4"
+							<Bars3Icon
+								className="items-center z-50 transition-transform transform hover:scale-110 mt-2 mr-4 w-10 h-10 stroke-nomad-green cursor-pointer"
 								onClick={() => {
 									setIsOpen(!isOpen);
 								}}
-							>
-								<svg
-									xmlns="http://www.w3.org/2000/svg"
-									fill="none"
-									viewBox="0 0 24 24"
-									strokeWidth={1.5}
-									className="w-10 h-10 z-50 stroke-nomad-green"
-								>
-									<path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
-								</svg>
-							</button>
+							/>
 						</div>
 					)}
 				</div>

--- a/src/components/SideBar/views/SideBarContent.tsx
+++ b/src/components/SideBar/views/SideBarContent.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { XMarkIcon, ChevronUpIcon, ChevronDownIcon } from '@heroicons/react/24/outline';
 import Menu from './Menu';
 
 interface SideBarProps {
@@ -30,30 +31,18 @@ function SideBarContent({ setIsOpen }: SideBarProps) {
 	return (
 		<nav id="SideBar-Content" className="z-50 bg-nomad-green min-h-screen h-full w-80 fixed">
 			<div className="flex flex-col">
-				<button
-					type="button"
-					id="CloseButton"
-					className="z-50 mt-2 mr-4 w-fit self-end transition-transform transform hover:scale-110"
+				<XMarkIcon
+					className="z-50 mt-2 mr-4 self-end transition-transform transform hover:scale-110 w-10 h-10 stroke-nomad-sand cursor-pointer"
 					onClick={() => {
 						setIsOpen(false);
 					}}
-				>
-					<svg
-						xmlns="http://www.w3.org/2000/svg"
-						fill="none"
-						viewBox="0 0 24 24"
-						strokeWidth={1.5}
-						className="w-10 h-10 z-50 stroke-nomad-sand"
-					>
-						<path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-					</svg>
-				</button>
+				/>
 				<ul className="z-50 w-full pr-7 ">
-					<Menu link="/checkSeat" name="자리 확인" />
-					<Menu link="/meetingRoom" name="회의실" />
-					<Menu link="/clusterMap" name="클러스터 맵" />
-					<Menu link="/lostItem" name="분실 게시판" />
-					<Menu link="/myPage" name="마이페이지" />
+					<Menu link="/checkSeat" name="⭐️ 자리 확인" />
+					<Menu link="/meetingRoom" name="👨‍👩‍👧‍👦 회의실" />
+					<Menu link="/cluster" name="🖥️ 클러스터 맵" />
+					<Menu link="/lost" name="📌 분실 게시판" />
+					<Menu link="/myPage" name="🏠 마이페이지" />
 				</ul>
 				<ul className="z-50 w-full pr-7">
 					{/* <Menu link="/quickSearch" name="빠른 자리 검색" /> */}

--- a/src/components/SideBar/views/SideBarContent.tsx
+++ b/src/components/SideBar/views/SideBarContent.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import { XMarkIcon, ChevronUpIcon, ChevronDownIcon } from '@heroicons/react/24/outline';
 import Menu from './Menu';
+import SearchSeat from '../../SearchSeat/SearchSeat';
 
 interface SideBarProps {
 	setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 function SideBarContent({ setIsOpen }: SideBarProps) {
+	const [searchSeat, setSearchSet] = React.useState<boolean>(false);
 	/*
     const side = useRef<HTMLDivElement>(null);
 
@@ -44,13 +46,26 @@ function SideBarContent({ setIsOpen }: SideBarProps) {
 					<Menu link="/lost" name="📌 분실 게시판" />
 					<Menu link="/myPage" name="🏠 마이페이지" />
 				</ul>
-				<ul className="z-50 w-full pr-7">
+				<ul className="z-50 w-full pr-7 ">
 					{/* <Menu link="/quickSearch" name="빠른 자리 검색" /> */}
 					<li className="z-50 w-full h-14 flex items-center justify-end text-nomad-sand text-xl transition-transform transform hover:scale-105">
-						빠른 자리 검색
-						{/* <SearchSeat /> */}
+						<button
+							type="button"
+							onClick={() => {
+								setSearchSet(!searchSeat);
+							}}
+							className="flex flex-row items-center space-x-1"
+						>
+							{searchSeat ? <ChevronUpIcon className="w-6 h-6" /> : <ChevronDownIcon className="w-6 h-6" />}
+							<div>빠른 자리 검색</div>
+						</button>
 					</li>
 				</ul>
+				{searchSeat && (
+					<div className="flex justify-center">
+						<SearchSeat />
+					</div>
+				)}
 			</div>
 		</nav>
 	);

--- a/src/pages/CheckSeat/views/CheckSeat.tsx
+++ b/src/pages/CheckSeat/views/CheckSeat.tsx
@@ -1,4 +1,5 @@
 import React, { useRef, useState } from 'react';
+import { PlusCircleIcon } from '@heroicons/react/24/outline';
 import SideBar from '../../../components/SideBar/views/SideBar';
 import SeatButton from './SeatButton';
 import Seat from './Seat';
@@ -41,27 +42,12 @@ function CheckSeat() {
 							id="Seat"
 							className="bg-nomad-green text-nomad-sand  shadow-sm shadow-zinc-900/5 rounded-3xl text-md w-5/6 h-14 pt-3 pl-5 pr-5 pb-3 flex justify-center items-center"
 						>
-							<button
-								type="button"
+							<PlusCircleIcon
+								className="w-10 h-10"
 								onClick={() => {
 									setIsModalOpen(true);
 								}}
-							>
-								<svg
-									xmlns="http://www.w3.org/2000/svg"
-									fill="none"
-									viewBox="0 0 24 24"
-									strokeWidth={1.5}
-									stroke="currentColor"
-									className="w-10 h-10"
-								>
-									<path
-										strokeLinecap="round"
-										strokeLinejoin="round"
-										d="M12 9v6m3-3H9m12 0a9 9 0 11-18 0 9 9 0 0118 0z"
-									/>
-								</svg>
-							</button>
+							/>
 						</div>
 						{isModalOpen && (
 							<div

--- a/src/pages/CheckSeat/views/CheckSeat.tsx
+++ b/src/pages/CheckSeat/views/CheckSeat.tsx
@@ -1,10 +1,14 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import SideBar from '../../../components/SideBar/views/SideBar';
 import SeatButton from './SeatButton';
 import Seat from './Seat';
+import SearchSeat from '../../../components/SearchSeat/SearchSeat';
 
 function CheckSeat() {
 	const [isStarred, setIsStarred] = useState(true);
+	const [isModalOpen, setIsModalOpen] = useState(false);
+	const modal = useRef<HTMLDivElement>(null);
+
 	return (
 		<div>
 			<SideBar />
@@ -37,7 +41,12 @@ function CheckSeat() {
 							id="Seat"
 							className="bg-nomad-green text-nomad-sand  shadow-sm shadow-zinc-900/5 rounded-3xl text-md w-5/6 h-14 pt-3 pl-5 pr-5 pb-3 flex justify-center items-center"
 						>
-							<button type="button">
+							<button
+								type="button"
+								onClick={() => {
+									setIsModalOpen(true);
+								}}
+							>
 								<svg
 									xmlns="http://www.w3.org/2000/svg"
 									fill="none"
@@ -54,6 +63,14 @@ function CheckSeat() {
 								</svg>
 							</button>
 						</div>
+						{isModalOpen && (
+							<div
+								ref={modal}
+								className="fixed top-0 left-0 w-full h-full flex justify-center items-center backdrop-blur-sm"
+							>
+								<SearchSeat />
+							</div>
+						)}
 					</div>
 				)}
 			</div>

--- a/src/pages/MeetingRoom/views/C1Map.tsx
+++ b/src/pages/MeetingRoom/views/C1Map.tsx
@@ -2,8 +2,11 @@ import React from 'react';
 
 function C1Map() {
 	return (
-		<div id="MeetingMap" className="grid grid-cols-6 grid-rows-12 h-2/3 w-2/3 mt-5 divide-black divide-y-2 divide-x-2">
-			<div className="col-span-2 row-span-1 flex justify-center items-center bg-meeting-disable text-nomad-sand">
+		<div
+			id="MeetingMap"
+			className="grid grid-cols-6 grid-rows-12 h-2/3 w-2/3 mt-5 divide-black divide-y-2 divide-x-2 border-black border-r-2 border-b-2"
+		>
+			<div className="col-span-2 row-span-1 flex justify-center items-center bg-meeting-disable text-nomad-sand border-black border-t-2 border-l-2">
 				사물함
 			</div>
 			<div className="col-start-3 col-span-1 row-span-full flex justify-center items-center bg-meeting-disable text-nomad-sand">

--- a/src/pages/MeetingRoom/views/C3Map.tsx
+++ b/src/pages/MeetingRoom/views/C3Map.tsx
@@ -4,9 +4,9 @@ function C3Map() {
 	return (
 		<div
 			id="MeetingMap"
-			className="grid grid-cols-5 grid-rows-12 h-2/3 w-2/3 mt-5 divide-meeting-disable border-meeting-disable divide-y-2 border-r-2"
+			className="grid grid-cols-5 grid-rows-12 h-2/3 w-2/3 mt-5 divide-black divide-y-2 divide-x-2 border-black border-b-2 border-r-2"
 		>
-			<div className="col-span-2 row-span-full flex items-center justify-center bg-meeting-disable text-nomad-sand">
+			<div className="col-span-2 row-span-full flex items-center justify-center bg-meeting-disable text-nomad-sand border-black border-t-2 border-l-2">
 				C3 Cluster
 			</div>
 			<div className="col-span-3 flex justify-center items-center bg-meeting-disable text-nomad-sand">사물함</div>

--- a/src/pages/MeetingRoom/views/C5Map.tsx
+++ b/src/pages/MeetingRoom/views/C5Map.tsx
@@ -4,17 +4,17 @@ function C5Map() {
 	return (
 		<div
 			id="MeetingMap"
-			className="grid grid-cols-5 grid-rows-10 h-2/3 w-2/3 mt-5 divide-meeting-disable border-meeting-disable divide-y-2 border-r-2"
+			className="grid grid-cols-3 grid-rows-10 h-2/3 w-2/3 mt-5 divide-black border-black divide-y-2 divide-x-2 border-r-2 border-b-2"
 		>
-			<div className="col-span-2 row-span-full flex items-center justify-center bg-meeting-disable text-nomad-sand">
+			<div className="col-span-1 row-span-full flex items-center justify-center bg-meeting-disable text-nomad-sand border-black border-t-2 border-l-2">
 				C5 Cluster
 			</div>
-			<div className="col-span-3 flex justify-center items-center bg-meeting-disable text-nomad-sand">사물함</div>
-			<div className="col-span-3 row-span-6 flex flex-col justify-center items-center bg-meeting-disable text-nomad-sand">
+			<div className="col-span-2 flex justify-center items-center bg-meeting-disable text-nomad-sand">사물함</div>
+			<div className="col-span-2 row-span-5 flex flex-col justify-center items-center bg-meeting-disable text-nomad-sand">
 				좌식공간
 			</div>
-			<div className="col-span-3 row-span-2 flex justify-center bg-white text-black items-center">TABLE</div>
-			<div className="col-span-3 flex justify-center items-center bg-meeting-disable text-nomad-sand">사물함</div>
+			<div className="col-span-2 row-span-3 flex justify-center bg-white text-black items-center">TABLE</div>
+			<div className="col-span-2 flex justify-center items-center bg-meeting-disable text-nomad-sand">사물함</div>
 		</div>
 	);
 }

--- a/src/pages/MeetingRoom/views/Cx2Map.tsx
+++ b/src/pages/MeetingRoom/views/Cx2Map.tsx
@@ -2,8 +2,11 @@ import React from 'react';
 
 function Cx2Map() {
 	return (
-		<div id="MeetingMap" className="grid grid-cols-6 grid-rows-6 h-2/3 w-3/4 mt-5 divide-black divide-y-2 divide-x-2">
-			<div className="col-span-1 row-span-1 flex items-center justify-center bg-meeting-disable text-nomad-sand">
+		<div
+			id="MeetingMap"
+			className="grid grid-cols-6 grid-rows-6 h-2/3 w-3/4 mt-5 divide-black divide-y-2 divide-x-2 border-black border-r-2 border-b-2"
+		>
+			<div className="col-span-1 row-span-1 flex items-center justify-center bg-meeting-disable text-nomad-sand border-black border-t-2 border-l-2">
 				좌석
 			</div>
 			<div className="col-span-3 row-span-1 flex justify-center items-center bg-white text-black">다각형책상</div>


### PR DESCRIPTION
1. 즐겨찾기 화면에 자리검색 모달을 추가했어요.
2. 사이드바 컴포넌트에 자리검색 컴포넌트를 추가했어요.
3. 사이드바, 즐겨찾기, 사이드바 컨텐츠 화면등에서 사용하고 있는  heroicon 아이콘들을 패키지를 통한 import로 수정했어요. 그 과정에서 @heroicons/react 패키지를 추가했어요.
4. 회의실 화면에서 빠져보이던 border를 추가했어요. 맨 첫 div에 border-t, border-l을 주고 마지막 div에 border-r, border-b를 부여했어요. 이 부분은 나중에 회의실 컴포넌트를 styled-component 로 변경하는 과정에서 하나의 style 로 변경할 예정이에요.
5. 사이드바에 메뉴들 앞에 이모지를 달고, 활성화 된 메뉴만 폰트를 볼드로 변경했어요. 지난번에 정하지 않은 회의실, 마이페이지, 클러스터 이모지는 임의로 정했는데, 혹시 바꾸고 싶은 이모지가 있다면 알려주세요.
6. 자리 검색 컴포넌트에 headless ui 콤보박스를 사용했습니다. 콤보박스 내부에서 보여줄 컨텐츠들이 cluster, row, seat 가 달라서 일단 2개를 구성했는데, 상태나 flag를 통해서 합칠 수 있는 방법이 있는지 알아볼게요 :D 

아래는 이번에 제작한  searchSeat component에요. 보고 수정할 사항이 있다면 언제든 코멘트 달아주세요.
<img width="473" alt="Screenshot 2023-08-25 at 6 05 29 PM" src="https://github.com/42nomad/frontend/assets/46983641/6ae79110-2b15-4fcc-b066-2df30d68ef8a">

<img width="477" alt="Screenshot 2023-08-25 at 6 05 49 PM" src="https://github.com/42nomad/frontend/assets/46983641/348adc06-5caf-4fed-80d0-76830b75421d">
