### PR TITLE
[REFACTOR] : admin, stat페이지 로고 컴포넌트로 변경

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,24 +1,15 @@
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { useSelector } from 'react-redux';
 import { Bars3Icon } from '@heroicons/react/24/outline';
-import { RootState } from '../../store/store';
-import switchHome from '../../utils/switchHome';
 import SideBar from './SideBar';
+import Logo from './Logo';
 
 function Header() {
-	const nav = useNavigate();
 	const [isOpen, setIsOpen] = useState(false);
-	const home = useSelector((state: RootState) => state.home.home);
 
 	return (
 		<div id="Header" className="z-40 w-full max-w-max-wid bg-nomad-sand fixed">
 			<div className="flex justify-between">
-				<button type='button' className="h-15 mt-4 ml-4" onClick={()=>switchHome(home, nav)}>
-					<div id="Logo" className="font-fugazRegular text-2xl text-nomad-green cursor-pointer">
-						42NOMAD
-					</div>
-				</button>
+				<Logo />
 				{!isOpen && (
 					<div id="HamburgerButton" className="z-50 bg-transparent">
 						<Bars3Icon

--- a/src/components/Header/Logo.tsx
+++ b/src/components/Header/Logo.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import { RootState } from '../../store/store';
+import switchHome from '../../utils/switchHome';
+
+function Logo() {
+	const nav = useNavigate();
+	const home = useSelector((state: RootState) => state.home.home);
+
+	return (
+		<button type="button" className="h-15 mt-4 ml-4" onClick={() => switchHome(home, nav)}>
+			<div id="Logo" className="font-fugazRegular text-2xl text-nomad-green cursor-pointer">
+				42NOMAD
+			</div>
+		</button>
+	);
+}
+
+export default Logo;

--- a/src/pages/Admin/views/Admin.tsx
+++ b/src/pages/Admin/views/Admin.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { Link } from 'react-router-dom';
 import { css } from '@emotion/react';
 import tw from 'twin.macro';
 import handleSecretUpdate from '../logics/handleSecretUpdate';
@@ -10,6 +9,7 @@ import handleAmdinLogin from '../logics/handleAdminLogin';
 import handleSlackAddress from '../logics/handleSlackAddress';
 import Loading from '../../../components/Loading/Loading';
 import getAdminRole from '../../../services/getAdminRole';
+import Logo from '../../../components/Header/Logo';
 
 const input = css`
 	${tw`px-4 m-1 rounded-xl border-2 border-nomad-green focus:outline-none`}
@@ -31,11 +31,7 @@ function Admin() {
 
 	return (
 		<div className="flex flex-col items-center text-xl w-full h-full bg-nomad-sand space-y-10">
-			<Link to="/staff" className="flex self-start bg-nomad-sand fixed">
-				<div id="Logo" className="flex h-15 mt-4 ml-4 font-fugazRegular text-2xl text-nomad-green cursor-pointer">
-					42NOMAD
-				</div>
-			</Link>
+			<Logo />
 			<div className="mt-32 font-nexonBold">Admin Page</div>
 			{isLoading ? <Loading /> : null}
 			<div className="w-80">

--- a/src/pages/Stat/views/Stat.tsx
+++ b/src/pages/Stat/views/Stat.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { CSVLink } from 'react-csv';
-import { Link } from 'react-router-dom';
 import 'react-datepicker/dist/react-datepicker.css';
 import StatStarred from './StatStarred';
 import StatMeeting from './StatMeeting';
@@ -8,6 +7,7 @@ import ExcelHeader from '../../../interfaces/ExcelHeader';
 import ExcelData from '../../../interfaces/ExcelData';
 import getExcelData from '../logics/getExcelData';
 import getStatRole from '../../../services/getStatRole';
+import Logo from '../../../components/Header/Logo';
 
 const clusters = [
 	{ id: 0, name: '전체' },
@@ -43,12 +43,10 @@ function Stat() {
 
 	return (
 		<>
-			<Link to="/staff" className="w-full max-w-max-wid bg-nomad-sand fixed">
-				<div id="Logo" className="flex h-15 mt-4 ml-4 font-fugazRegular text-2xl text-nomad-green cursor-pointer">
-					42NOMAD
-				</div>
-			</Link>
-			<div className="bg-nomad-sand h-full">
+			<div id="Header" className="z-40 w-full max-w-max-wid bg-nomad-sand fixed">
+				<Logo />
+			</div>
+			<div className="bg-nomad-sand min-h-full">
 				<div className="pt-16 pl-10 mb-4">
 					<div className="flex items-center text-3xl mr-2">ㄴ통계</div>
 				</div>
@@ -118,7 +116,7 @@ function Stat() {
 					</CSVLink>
 				</div>
 				{excelData.length !== 0 && (
-					<div className="flex justify-center items-center mt-6">
+					<div className="bg-nomad-sand flex justify-center items-center mt-6">
 						<table className="table-fixed border-2 border-collapse">
 							<thead className="bg-zinc-200">
 								<tr>


### PR DESCRIPTION
- stat 페이지와 admin페이지에 달려있던 로고를 헤더의 로고로 변경했습니다. 
그 과정에서 헤더의 로고를 분리해서 새로운 컴포넌트로 만들어주었어요. 
효과는 굉장했다! 재사용성이 +2만큼 증가했다!입니다.

- stat페이지에서 통계자료를 볼때 자료의 양이 많으면 스크롤이 생기는데 밑에 부분에는 백그라운드가 적용이 안되는 이슈를 발견했어요! 
이것도 함께 수정해주었습니다.

미리 이야기한대로, 제가 머지할게요!